### PR TITLE
Add tests for metrics registry

### DIFF
--- a/src/commonTest/kotlin/com/jillesvangurp/multiplatformmetrics/InMemoryRegistryTest.kt
+++ b/src/commonTest/kotlin/com/jillesvangurp/multiplatformmetrics/InMemoryRegistryTest.kt
@@ -1,0 +1,65 @@
+package com.jillesvangurp.multiplatformmetrics
+
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.doubles.shouldBeExactly
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class InMemoryRegistryTest {
+    @Test
+    fun counterShouldRecordIncrements() {
+        val registry = InMemoryRegistry()
+        val counter = registry.counter("hits", mapOf("route" to "test"))
+        counter.inc()
+        counter.inc(2)
+
+        val snapshot = registry.snapshot()
+        snapshot.points.size shouldBe 1
+        val point = snapshot.points.first()
+        point.type shouldBe "counter"
+        point.name shouldBe "hits"
+        point.tags shouldBe mapOf("route" to "test")
+        point.count shouldBe 3
+    }
+
+    @Test
+    fun gaugeShouldRecordLastValue() {
+        val registry = InMemoryRegistry()
+        val gauge = registry.gauge("load")
+        gauge.set(1.0)
+        gauge.set(2.5)
+
+        val point = registry.snapshot().points.first()
+        point.type shouldBe "gauge"
+        point.name shouldBe "load"
+        point.value.shouldBeExactly(2.5)
+    }
+
+    @Test
+    fun timerShouldRecordDurations() {
+        val registry = InMemoryRegistry()
+        val timer = registry.timer("latency")
+        timer.record(10)
+        timer.record(20)
+
+        val point = registry.snapshot().points.first()
+        point.type shouldBe "timer"
+        point.name shouldBe "latency"
+        point.count shouldBe 2
+        point.sumMs.shouldBeExactly(30.0)
+        point.minMs.shouldBeExactly(10.0)
+        point.maxMs.shouldBeExactly(20.0)
+    }
+
+    @Test
+    fun snapshotShouldContainAllMetrics() {
+        val registry = InMemoryRegistry()
+        registry.counter("c").inc()
+        registry.gauge("g").set(1.0)
+        registry.timer("t").record(1)
+
+        val names = registry.snapshot().points.map { it.name }
+        names.shouldContainExactly("c", "g", "t")
+    }
+}
+

--- a/src/commonTest/kotlin/com/jillesvangurp/multiplatformmetrics/InMemoryRegistryTest.kt
+++ b/src/commonTest/kotlin/com/jillesvangurp/multiplatformmetrics/InMemoryRegistryTest.kt
@@ -1,7 +1,6 @@
 package com.jillesvangurp.multiplatformmetrics
 
 import io.kotest.matchers.collections.shouldContainExactly
-import io.kotest.matchers.doubles.shouldBeExactly
 import io.kotest.matchers.shouldBe
 import kotlin.test.Test
 
@@ -32,7 +31,7 @@ class InMemoryRegistryTest {
         val point = registry.snapshot().points.first()
         point.type shouldBe "gauge"
         point.name shouldBe "load"
-        point.value.shouldBeExactly(2.5)
+        point.value shouldBe 2.5
     }
 
     @Test
@@ -46,9 +45,9 @@ class InMemoryRegistryTest {
         point.type shouldBe "timer"
         point.name shouldBe "latency"
         point.count shouldBe 2
-        point.sumMs.shouldBeExactly(30.0)
-        point.minMs.shouldBeExactly(10.0)
-        point.maxMs.shouldBeExactly(20.0)
+        point.sumMs shouldBe 30.0
+        point.minMs shouldBe 10.0
+        point.maxMs shouldBe 20.0
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add common tests covering counters, gauges, timers, and registry snapshot
- refine tests to use Kotest assertions per guidelines

## Testing
- `./gradlew jvmTest` *(fails: Could not resolve com.github.jillesvangurp:kotlin4example:1.1.9 from jitpack)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d3b5ae3c832ead841eedf27bf4ab