### PR TITLE
chore: clean up build warnings

### DIFF
--- a/.github/workflows/pr_master.yaml
+++ b/.github/workflows/pr_master.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
         with:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
-          add-job-summary: true
+          add-job-summary: always
 
       - name: Build with Gradle
         run: ./gradlew check

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,5 @@ group=com.jillesvangurp
 kotlin.mpp.stability.nowarn=true
 org.gradle.configuration-cache=true
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m -Xmx2g -Dkotlin.daemon.jvm.options=-Xmx2g
+kotlin.native.ignoreDisabledTargets=true
 


### PR DESCRIPTION
## Summary
- silence Kotlin/Native disabled target warnings
- fix workflow job summary setting to avoid post-action errors

## Testing
- `./gradlew jvmTest` *(fails: Could not resolve com.github.jillesvangurp:kotlin4example:1.1.9, received status code 403 from server: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d7a2f830832eb88849f083a0d12b