### PR TITLE
Add percentile and SLA support to timers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Multiplatform Metrics
 
-Kotlin multiplatform metrics registry with counters, gauges, timers and summaries.
+Kotlin multiplatform metrics registry with counters, gauges, timers and summaries. Timers support percentiles and SLA boundaries. On JVM, you can publish to a micrometer MeterRegistry (like comes with Spring).
 
-Note this is a work in progress and the API may evolve.
+Intended to have a more Kotlin native feel to it. Which means DSLs, using durations and building on other stuff in `kotlin.time` package.
+
+**Note** this is a work in progress and the API may evolve.
 
 ## Examples
 
@@ -44,6 +46,52 @@ Produces
 
 ```text
 12.3
+```
+
+### Timer percentiles and SLA
+
+```kotlin
+val registry = SimpleMeterRegistry()
+val timer = registry.timer(
+  "latency",
+  config = TimerConfig(percentiles = listOf(0.5), sla = listOf(50.milliseconds))
+)
+listOf(10, 50, 100).forEach { timer.record(it.milliseconds) }
+println(registry.snapshot().toJson(pretty = true))
+```
+
+Produces
+
+```text
+{
+  "points": [
+    {
+      "type": "timer",
+      "name": "latency",
+      "tags": {},
+      "count": 3,
+      "sum": 160.0,
+      "min": 10.0,
+      "max": 100.0
+    },
+    {
+      "type": "timer",
+      "name": "latency",
+      "tags": {
+        "percentile": "0.5"
+      },
+      "value": 50.0
+    },
+    {
+      "type": "timer",
+      "name": "latency",
+      "tags": {
+        "sla": "50"
+      },
+      "count": 2
+    }
+  ]
+}
 ```
 
 ## Multi platform

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,14 +78,15 @@ kotlin {
             }
         }
 
-        commonTest {
-            dependencies {
-                implementation(kotlin("test"))
-                implementation(kotlin("test-common"))
-                implementation(kotlin("test-annotations-common"))
-                implementation("io.kotest:kotest-assertions-core:_")
-            }
-        }
+          commonTest {
+              dependencies {
+                  implementation(kotlin("test"))
+                  implementation(kotlin("test-common"))
+                  implementation(kotlin("test-annotations-common"))
+                  implementation("io.kotest:kotest-assertions-core:_")
+                  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:_")
+              }
+          }
 
         jvmMain  {
             dependencies {

--- a/src/commonMain/kotlin/com/jillesvangurp/multiplatformmetrics/MeterRegistry.kt
+++ b/src/commonMain/kotlin/com/jillesvangurp/multiplatformmetrics/MeterRegistry.kt
@@ -22,8 +22,12 @@ interface IMeterRegistry {
     /** Create or retrieve a [Gauge] named [name] with optional [tags]. */
     fun gauge(name: String, tags: Map<String, String> = emptyMap()): Gauge
 
-    /** Create or retrieve a [Timer] named [name] with optional [tags]. */
-    fun timer(name: String, tags: Map<String, String> = emptyMap()): Timer
+    /** Create or retrieve a [Timer] named [name] with optional [tags] and [config]. */
+    fun timer(
+        name: String,
+        tags: Map<String, String> = emptyMap(),
+        config: TimerConfig = TimerConfig()
+    ): Timer
 
     /** Create or retrieve a [DistributionSummary] named [name] with optional [tags]. */
     fun summary(name: String, tags: Map<String, String> = emptyMap()): DistributionSummary

--- a/src/commonMain/kotlin/com/jillesvangurp/multiplatformmetrics/Timer.kt
+++ b/src/commonMain/kotlin/com/jillesvangurp/multiplatformmetrics/Timer.kt
@@ -1,7 +1,6 @@
 package com.jillesvangurp.multiplatformmetrics
 
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
 
 /** A timer that records durations. */
 interface Timer {
@@ -11,3 +10,9 @@ interface Timer {
     /** Add an explicit [duration]. */
     fun record(duration: Duration)
 }
+
+/** Configuration for [Timer] percentiles and SLA boundaries. */
+data class TimerConfig(
+    val percentiles: List<Double> = emptyList(),
+    val sla: List<Duration> = emptyList()
+)

--- a/src/jvmTest/kotlin/com/jillesvangurp/docs/readme/ReadmeGenerationTest.kt
+++ b/src/jvmTest/kotlin/com/jillesvangurp/docs/readme/ReadmeGenerationTest.kt
@@ -3,8 +3,10 @@ package com.jillesvangurp.docs.readme
 import com.jillesvangurp.kotlin4example.SourceRepository
 import com.jillesvangurp.multiplatformmetrics.MicrometerMeterRegistry
 import com.jillesvangurp.multiplatformmetrics.SimpleMeterRegistry
+import com.jillesvangurp.multiplatformmetrics.TimerConfig
 import java.io.File
 import kotlin.test.Test
+import kotlin.time.Duration.Companion.milliseconds
 
 const val githubLink = "https://github.com/jillesvangurp/multiplatform-metrics"
 
@@ -47,20 +49,36 @@ val readmeMd =
                     mdCodeBlock(out.stdOut, type = "text")
                 }
             }
-            subSection("Micrometer on the JVM") {
-                example {
-                    val micrometer = io.micrometer.core.instrument.simple.SimpleMeterRegistry()
-                    val registry = MicrometerMeterRegistry(micrometer)
-                    val gauge = registry.gauge("temp")
-                    gauge.set(12.3)
-                    println(micrometer.get("temp").gauge().value())
-                }.let { out ->
-                    +"""
-                        Produces
-                    """.trimIndent()
-                    mdCodeBlock(out.stdOut, type = "text")
-                }
-            }
-        }
-        includeMdFile("outro.md")
-    }
+              subSection("Micrometer on the JVM") {
+                  example {
+                      val micrometer = io.micrometer.core.instrument.simple.SimpleMeterRegistry()
+                      val registry = MicrometerMeterRegistry(micrometer)
+                      val gauge = registry.gauge("temp")
+                      gauge.set(12.3)
+                      println(micrometer.get("temp").gauge().value())
+                  }.let { out ->
+                      +"""
+                          Produces
+                      """.trimIndent()
+                      mdCodeBlock(out.stdOut, type = "text")
+                  }
+              }
+              subSection("Timer percentiles and SLA") {
+                  example {
+                      val registry = SimpleMeterRegistry()
+                      val timer = registry.timer(
+                          "latency",
+                          config = TimerConfig(percentiles = listOf(0.5), sla = listOf(50.milliseconds))
+                      )
+                      listOf(10, 50, 100).forEach { timer.record(it.milliseconds) }
+                      println(registry.snapshot().toJson(pretty = true))
+                  }.let { out ->
+                      +"""
+                          Produces
+                      """.trimIndent()
+                      mdCodeBlock(out.stdOut, type = "text")
+                  }
+              }
+          }
+          includeMdFile("outro.md")
+      }

--- a/src/jvmTest/kotlin/com/jillesvangurp/docs/readme/intro.md
+++ b/src/jvmTest/kotlin/com/jillesvangurp/docs/readme/intro.md
@@ -1,4 +1,4 @@
-Kotlin multiplatform metrics registry with simple counters, gauges, timers and summaries. On JVM, you can publish to a micrometer MeterRegistry (like comes with Spring).
+Kotlin multiplatform metrics registry with counters, gauges, timers and summaries. Timers support percentiles and SLA boundaries. On JVM, you can publish to a micrometer MeterRegistry (like comes with Spring).
 
 Intended to have a more Kotlin native feel to it. Which means DSLs, using durations and building on other stuff in `kotlin.time` package.
 

--- a/versions.properties
+++ b/versions.properties
@@ -25,7 +25,10 @@ version.kotlin=2.2.10
 ## # available=2.2.20-Beta2
 ## # available=2.2.20-RC
 
+version.kotlinx.coroutines=1.10.2
+
 version.kotlinx.serialization=1.9.0
 
 version.org.jetbrains.kotlinx..atomicfu=0.29.0
+
 version.io.micrometer..micrometer-core=1.15.3


### PR DESCRIPTION
## Summary
- allow configuring timers with percentiles and SLA boundaries
- support percentile and SLA metrics in SimpleMeterRegistry and Micrometer integration
- document timer configuration with examples

## Testing
- `./gradlew jvmTest`
- `./gradlew build` *(fails: No binary for ChromeHeadless browser, Unable to tunnel through proxy for Kotlin/Native)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e45ab5f8832e9d5155aa63db70d1