### PR TITLE
Add OpenTelemetry and Prometheus exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,35 @@ Produces
 }
 ```
 
+### OpenTelemetry JSON lines
+
+```kotlin
+val registry = SimpleMeterRegistry()
+registry.counter("hits").inc()
+val line = registry.snapshot().toOpenTelemetryJsonLines().first()
+println((line.take(77) + "...").trim())
+```
+
+Produces
+
+```text
+{"resourceMetrics":[{"scopeMetrics":[{"metrics":[{"name":"hits","sum":{"aggre...
+```
+
+### Prometheus lines
+
+```kotlin
+val registry = SimpleMeterRegistry()
+registry.counter("hits").inc()
+println(registry.snapshot().toPrometheusLines().joinToString("\n"))
+```
+
+Produces
+
+```text
+hits 1
+```
+
 ## Multi platform
 
 This is a Kotlin multi platform library that should work on all kotlin platforms (jvm, js, wasm, native, ios, android, etc).

--- a/src/jvmTest/kotlin/com/jillesvangurp/docs/readme/ReadmeGenerationTest.kt
+++ b/src/jvmTest/kotlin/com/jillesvangurp/docs/readme/ReadmeGenerationTest.kt
@@ -79,6 +79,31 @@ val readmeMd =
                       mdCodeBlock(out.stdOut, type = "text")
                   }
               }
+              subSection("OpenTelemetry JSON lines") {
+                  example {
+                      val registry = SimpleMeterRegistry()
+                      registry.counter("hits").inc()
+                      val line = registry.snapshot().toOpenTelemetryJsonLines().first()
+                      println((line.take(77) + "...").trim())
+                  }.let { out ->
+                      +"""
+                          Produces
+                      """.trimIndent()
+                      mdCodeBlock(out.stdOut, type = "text")
+                  }
+              }
+              subSection("Prometheus lines") {
+                  example {
+                      val registry = SimpleMeterRegistry()
+                      registry.counter("hits").inc()
+                      println(registry.snapshot().toPrometheusLines().joinToString("\n"))
+                  }.let { out ->
+                      +"""
+                          Produces
+                      """.trimIndent()
+                      mdCodeBlock(out.stdOut, type = "text")
+                  }
+              }
           }
           includeMdFile("outro.md")
       }


### PR DESCRIPTION
## Summary
- support exporting metrics snapshot as OpenTelemetry JSON lines
- add Prometheus text-format export helper
- document new export formats with examples and tests

## Testing
- `./gradlew jvmTest`
- `./gradlew build` *(fails: Errors occurred during launch of browser for testing; Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a71d9185ec832eb5249cd8cd6f9812